### PR TITLE
Add .zenodo.json to overwrite meta-data defaults

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,24 @@
+{
+  "metadata": {
+    "creators": [
+      {
+        "person_or_org": {
+          "family_name": "Frey",
+          "name": "Frey, Matthias",
+          "orcid": "0000-0002-7842-0051",
+          "affiliation": "University of St Andrews",
+          "type": "personal"
+        }
+      },
+      {
+        "person_or_org": {
+          "family_name": "Dritschel",
+          "name": "Dritschel, David",
+          "orcid": "0000-0001-6489-3395",
+          "affiliation": "University of St Andrews",
+          "type": "personal"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR adds the hidden file `.zenodo.json` to overwrite the meta-data defaults.