### PR TITLE
Use explicit setter to avoid character string issue

### DIFF
--- a/src/fields/field_diagnostics_netcdf.f90
+++ b/src/fields/field_diagnostics_netcdf.f90
@@ -29,13 +29,7 @@ module field_diagnostics_netcdf
     integer            :: ncid
     integer            :: t_axis_id, t_dim_id, n_writes
 
-    type netcdf_stat_info
-        character(32)    :: name      = ''
-        character(128)   :: long_name = ''
-        character(128)   :: std_name  = ''
-        character(16)    :: unit      = ''
-        integer          :: dtype     = -1
-        integer          :: varid     = -1
+    type, extends(netcdf_info) :: netcdf_stat_info
         double precision :: val       = zero   ! data to be written
     end type netcdf_stat_info
 
@@ -461,280 +455,280 @@ module field_diagnostics_netcdf
             use options, only : output
 #endif
 
-            nc_dset(NC_KE) = netcdf_stat_info(                          &
+            call nc_dset(NC_KE)%set_info(                               &
                 name='ke',                                              &
                 long_name='domain-averaged kinetic energy',             &
                 std_name='',                                            &
                 unit='m^2/s^2',                                         &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_EN) = netcdf_stat_info(                          &
+            call nc_dset(NC_EN)%set_info(                               &
                 name='en',                                              &
                 long_name='domain-averaged enstrophy',                  &
                 std_name='',                                            &
                 unit='1/s^2',                                           &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_OMAX) = netcdf_stat_info(                        &
+            call nc_dset(NC_OMAX)%set_info(                             &
                 name='vortmax',                                         &
                 long_name='maximum vorticity magnitude',                &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_ORMS) = netcdf_stat_info(                        &
+            call nc_dset(NC_ORMS)%set_info(                             &
                 name='vortrms',                                         &
                 long_name='root-mean square vorticity',                 &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_OCHAR) = netcdf_stat_info(                       &
+            call nc_dset(NC_OCHAR)%set_info(                            &
                 name='vorch',                                           &
                 long_name='characteristic vorticity',                   &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_OXMEAN) = netcdf_stat_info(                      &
+            call nc_dset(NC_OXMEAN)%set_info(                           &
                 name='x_vormean',                                       &
                 long_name='mean x-vorticity',                           &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_OYMEAN) = netcdf_stat_info(                      &
+            call nc_dset(NC_OYMEAN)%set_info(                           &
                 name='y_vormean',                                       &
                 long_name='mean y-vorticity',                           &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_OZMEAN) = netcdf_stat_info(                      &
+            call nc_dset(NC_OZMEAN)%set_info(                           &
                 name='z_vormean',                                       &
                 long_name='mean z-vorticity',                           &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_OXMIN) = netcdf_stat_info(                       &
+            call nc_dset(NC_OXMIN)%set_info(                            &
                 name='x_vormin',                                        &
                 long_name='min x-vorticity',                            &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_OYMIN) = netcdf_stat_info(                       &
+            call nc_dset(NC_OYMIN)%set_info(                            &
                 name='y_vormin',                                        &
                 long_name='min y-vorticity',                            &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_OZMIN) = netcdf_stat_info(                       &
+            call nc_dset(NC_OZMIN)%set_info(                            &
                 name='z_vormin',                                        &
                 long_name='min z-vorticity',                            &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_OXMAX) = netcdf_stat_info(                       &
+            call nc_dset(NC_OXMAX)%set_info(                            &
                 name='x_vormax',                                        &
                 long_name='max x-vorticity',                            &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_OYMAX) = netcdf_stat_info(                       &
+            call nc_dset(NC_OYMAX)%set_info(                            &
                 name='y_vormax',                                        &
                 long_name='max y-vorticity',                            &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_OZMAX) = netcdf_stat_info(                       &
+            call nc_dset(NC_OZMAX)%set_info(                            &
                 name='z_vormax',                                        &
                 long_name='max z-vorticity',                            &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_HEMAX) = netcdf_stat_info(                       &
+            call nc_dset(NC_HEMAX)%set_info(                            &
                 name='enxy_max',                                        &
                 long_name='max horizontal enstrophy',                   &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_GMAX) = netcdf_stat_info(                        &
+            call nc_dset(NC_GMAX)%set_info(                             &
                 name='gmax',                                            &
                 long_name='maximum gamma',                              &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-             nc_dset(NC_BFMAX) = netcdf_stat_info(                      &
+             call nc_dset(NC_BFMAX)%set_info(                           &
                 name='bfmax',                                           &
                 long_name='maximum buoyancy frequency',                 &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_UMAX) = netcdf_stat_info(                        &
+            call nc_dset(NC_UMAX)%set_info(                             &
                 name='umax',                                            &
                 long_name='maximum x-velocity',                         &
                 std_name='',                                            &
                 unit='m/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_VMAX) = netcdf_stat_info(                        &
+            call nc_dset(NC_VMAX)%set_info(                             &
                 name='vmax',                                            &
                 long_name='maximum y-velocity',                         &
                 std_name='',                                            &
                 unit='m/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_WMAX) = netcdf_stat_info(                        &
+            call nc_dset(NC_WMAX)%set_info(                             &
                 name='wmax',                                            &
                 long_name='maximum z-velocity',                         &
                 std_name='',                                            &
                 unit='m/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_USOXMAX) = netcdf_stat_info(                     &
+            call nc_dset(NC_USOXMAX)%set_info(                          &
                 name='uoxmax',                                          &
                 long_name='upper surface maximum x-vorticity',          &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_LSOXMAX) = netcdf_stat_info(                     &
+            call nc_dset(NC_LSOXMAX)%set_info(                          &
                 name='loxmax',                                          &
                 long_name='lower surface maximum x-vorticity',          &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_USOYMAX) = netcdf_stat_info(                     &
+            call nc_dset(NC_USOYMAX)%set_info(                          &
                 name='uoymax',                                          &
                 long_name='upper surface maximum y-vorticity',          &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_LSOYMAX) = netcdf_stat_info(                     &
+            call nc_dset(NC_LSOYMAX)%set_info(                          &
                 name='loymax',                                          &
                 long_name='lower surface maximum y-vorticity',          &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_USOZMAX) = netcdf_stat_info(                     &
+            call nc_dset(NC_USOZMAX)%set_info(                          &
                 name='uozmax',                                          &
                 long_name='upper surface maximum z-vorticity',          &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_LSOZMAX) = netcdf_stat_info(                     &
+            call nc_dset(NC_LSOZMAX)%set_info(                          &
                 name='lozmax',                                          &
                 long_name='lower surface maximum z-vorticity',          &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_USUHMAX) = netcdf_stat_info(                     &
+            call nc_dset(NC_USUHMAX)%set_info(                          &
                 name='usuhmax',                                         &
                 long_name='upper surface maximum horizontal speed',     &
                 std_name='',                                            &
                 unit='m/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_USGMAX) = netcdf_stat_info(                      &
+            call nc_dset(NC_USGMAX)%set_info(                           &
                 name='usgmax',                                          &
                 long_name='upper surface maximum strain',               &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_LSGMAX) = netcdf_stat_info(                      &
+            call nc_dset(NC_LSGMAX)%set_info(                           &
                 name='lsgmax',                                          &
                 long_name='lower surface maximum strain',               &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_USZRMS) = netcdf_stat_info(                      &
+            call nc_dset(NC_USZRMS)%set_info(                           &
                 name='uszrms',                                          &
                 long_name='rms of upper surface z-vorticity',           &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_USDELRMS) = netcdf_stat_info(                    &
+            call nc_dset(NC_USDELRMS)%set_info(                         &
                 name='usdeltarms',                                      &
                 long_name='rms of upper surface horizontal divergence', &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_RGMAX) = netcdf_stat_info(                       &
+            call nc_dset(NC_RGMAX)%set_info(                            &
                 name='rolling_mean_gmax',                               &
                 long_name='rolling mean maximum gamma',                 &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_RBFMAX) = netcdf_stat_info(                      &
+            call nc_dset(NC_RBFMAX)%set_info(                           &
                 name='rolling_mean_bfmax',                              &
                 long_name='rolling mean maximum buoyancy frequency',    &
                 std_name='',                                            &
                 unit='1/s',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_RIMIN) = netcdf_stat_info(                       &
+            call nc_dset(NC_RIMIN)%set_info(                            &
                 name='ri_min',                                          &
                 long_name='minimum Richardson number',                  &
                 std_name='',                                            &
                 unit='1',                                               &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_ROMIN) = netcdf_stat_info(                       &
+            call nc_dset(NC_ROMIN)%set_info(                            &
                 name='ro_min',                                          &
                 long_name='minimum Rossby number',                      &
                 std_name='',                                            &
                 unit='1',                                               &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_ROMAX) = netcdf_stat_info(                       &
+            call nc_dset(NC_ROMAX)%set_info(                            &
                 name='ro_max',                                          &
                 long_name='maximum Rossby number',                      &
                 std_name='',                                            &
                 unit='1',                                               &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_KEXY) = netcdf_stat_info(                        &
+            call nc_dset(NC_KEXY)%set_info(                             &
                 name='kexy',                                            &
                 long_name='domain-averaged horizontal kinetic energy',  &
                 std_name='',                                            &
                 unit='m^2/s^2',                                         &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_KEZ) = netcdf_stat_info(                         &
+            call nc_dset(NC_KEZ)%set_info(                              &
                 name='kez',                                             &
                 long_name='domain-averaged vertical kinetic energy',    &
                 std_name='',                                            &
                 unit='m^2/s^2',                                         &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_ENXY) = netcdf_stat_info(                        &
+            call nc_dset(NC_ENXY)%set_info(                             &
                 name='enxy',                                            &
                 long_name='domain-averaged horizontal enstrophy',       &
                 std_name='',                                            &
                 unit='1/s^2',                                           &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_ENZ) = netcdf_stat_info(                         &
+            call nc_dset(NC_ENZ)%set_info(                              &
                 name='enz',                                             &
                 long_name='domain-averaged vertical enstrophy',         &
                 std_name='',                                            &
@@ -742,28 +736,28 @@ module field_diagnostics_netcdf
                 dtype=NF90_DOUBLE)
 
 #ifdef ENABLE_BUOYANCY
-            nc_dset(NC_APE) = netcdf_stat_info(                         &
+            call nc_dset(NC_APE)%set_info(                              &
                 name='ape',                                             &
                 long_name='domain-averaged available potential energy', &
                 std_name='',                                            &
                 unit='m^2/s^2',                                         &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_BMIN) = netcdf_stat_info(                        &
+            call nc_dset(NC_BMIN)%set_info(                             &
                 name='min_buoyancy',                                    &
                 long_name='minimum buoyancy',                           &
                 std_name='',                                            &
                 unit='m/s^2',                                           &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_BMAX) = netcdf_stat_info(                        &
+            call nc_dset(NC_BMAX)%set_info(                             &
                 name='max_buoyancy',                                    &
                 long_name='maximum buoyancy',                           &
                 std_name='',                                            &
                 unit='m/s^2',                                           &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_MSS) = netcdf_stat_info(                         &
+            call nc_dset(NC_MSS)%set_info(                              &
                 name='minimum_static_stability',                        &
                 long_name='minimum static stability',                   &
                 std_name='',                                            &
@@ -771,28 +765,28 @@ module field_diagnostics_netcdf
                 dtype=NF90_DOUBLE)
 
             if (output%l_balanced) then
-                nc_dset(NC_KEBAL) = netcdf_stat_info(                       &
+                call nc_dset(NC_KEBAL)%set_info(                            &
                     name='kebal',                                           &
                     long_name='domain-averaged balanced kinetic energy',    &
                     std_name='',                                            &
                     unit='m^2/s^2',                                         &
                     dtype=NF90_DOUBLE)
 
-                nc_dset(NC_KEUBAL) = netcdf_stat_info(                      &
+                call nc_dset(NC_KEUBAL)%set_info(                           &
                     name='keubal',                                          &
                     long_name='domain-averaged imbalanced kinetic energy',  &
                     std_name='',                                            &
                     unit='m^2/s^2',                                         &
                     dtype=NF90_DOUBLE)
 
-                nc_dset(NC_APEBAL) = netcdf_stat_info(                      &
+                call nc_dset(NC_APEBAL)%set_info(                           &
                     name='apebal',                                          &
                     long_name='domain-averaged balanced APE',               &
                     std_name='',                                            &
                     unit='m^2/s^2',                                         &
                     dtype=NF90_DOUBLE)
 
-                nc_dset(NC_APEUBAL) = netcdf_stat_info(                     &
+                call nc_dset(NC_APEUBAL)%set_info(                          &
                     name='apeubal',                                         &
                     long_name='domain-averaged imbalanced APE',             &
                     std_name='',                                            &

--- a/src/fields/field_netcdf.f90
+++ b/src/fields/field_netcdf.f90
@@ -35,6 +35,10 @@ module field_netcdf
         integer        :: dtype     = -1
         integer        :: varid     = -1
         logical        :: l_enabled = .false.
+
+        contains
+            procedure set_info
+
     end type netcdf_field_info
 
     integer, parameter :: NC_X_VEL   = 1        &
@@ -64,6 +68,31 @@ module field_netcdf
 
 
     contains
+
+        subroutine set_info(this, name, long_name, std_name, unit, dtype)
+            class(netcdf_field_info), intent(inout) :: this
+            character(*),             intent(in)    :: name
+            character(*),             intent(in)    :: long_name
+            character(*),             intent(in)    :: std_name
+            character(*),             intent(in)    :: unit
+            integer,                  intent(in)    :: dtype
+            integer                                 :: l
+
+            l = len(name)
+            this%name(1:l) = name
+
+            l = len(long_name)
+            this%long_name(1:l) = long_name
+
+            l = len(std_name)
+            this%std_name(1:l) = std_name
+
+            l = len(unit)
+            this%unit(1:l) = unit
+
+            this%dtype = dtype
+
+        end subroutine set_info
 
         ! Create the field file.
         ! @param[in] basename of the file
@@ -511,71 +540,71 @@ module field_netcdf
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         subroutine set_netcdf_field_info
-            nc_dset(NC_X_VEL) = netcdf_field_info(name='x_velocity',                    &
-                                                  long_name='x velocity component',     &
-                                                  std_name='',                          &
-                                                  unit='m/s',                           &
-                                                  dtype=NF90_DOUBLE)
+            call nc_dset(NC_X_VEL)%set_info(name='x_velocity',                    &
+                                            long_name='x velocity component',     &
+                                            std_name='',                          &
+                                            unit='m/s',                           &
+                                            dtype=NF90_DOUBLE)
 
-            nc_dset(NC_Y_VEL) = netcdf_field_info(name='y_velocity',                    &
-                                                  long_name='y velocity component',     &
-                                                  std_name='',                          &
-                                                  unit='m/s',                           &
-                                                  dtype=NF90_DOUBLE)
+            call nc_dset(NC_Y_VEL)%set_info(name='y_velocity',                    &
+                                            long_name='y velocity component',     &
+                                            std_name='',                          &
+                                            unit='m/s',                           &
+                                            dtype=NF90_DOUBLE)
 
-            nc_dset(NC_Z_VEL) = netcdf_field_info(name='z_velocity',                    &
-                                                  long_name='z velocity component',     &
-                                                  std_name='',                          &
-                                                  unit='m/s',                           &
-                                                  dtype=NF90_DOUBLE)
+            call nc_dset(NC_Z_VEL)%set_info(name='z_velocity',                    &
+                                            long_name='z velocity component',     &
+                                            std_name='',                          &
+                                            unit='m/s',                           &
+                                            dtype=NF90_DOUBLE)
 
-            nc_dset(NC_X_VOR) = netcdf_field_info(name='x_vorticity',                   &
-                                                  long_name='x vorticity component',    &
-                                                  std_name='',                          &
-                                                  unit='1/s',                           &
-                                                  dtype=NF90_DOUBLE)
+            call nc_dset(NC_X_VOR)%set_info(name='x_vorticity',                   &
+                                            long_name='x vorticity component',    &
+                                            std_name='',                          &
+                                            unit='1/s',                           &
+                                            dtype=NF90_DOUBLE)
 
-            nc_dset(NC_Y_VOR) = netcdf_field_info(name='y_vorticity',                   &
-                                                  long_name='y vorticity component',    &
-                                                  std_name='',                          &
-                                                  unit='1/s',                           &
-                                                  dtype=NF90_DOUBLE)
+            call nc_dset(NC_Y_VOR)%set_info(name='y_vorticity',                   &
+                                            long_name='y vorticity component',    &
+                                            std_name='',                          &
+                                            unit='1/s',                           &
+                                            dtype=NF90_DOUBLE)
 
-            nc_dset(NC_Z_VOR) = netcdf_field_info(name='z_vorticity',                   &
-                                                  long_name='z vorticity component',    &
-                                                  std_name='',                          &
-                                                  unit='1/s',                           &
-                                                  dtype=NF90_DOUBLE)
+            call nc_dset(NC_Z_VOR)%set_info(name='z_vorticity',                   &
+                                            long_name='z vorticity component',    &
+                                            std_name='',                          &
+                                            unit='1/s',                           &
+                                            dtype=NF90_DOUBLE)
 
 #ifdef ENABLE_BUOYANCY
-            nc_dset(NC_PRES) = netcdf_field_info(name='pressure_anomaly',               &
-                                                 long_name='pressure anomaly',          &
+            call nc_dset(NC_PRES)%set_info(name='pressure_anomaly',               &
+                                           long_name='pressure anomaly',          &
 #else
-            nc_dset(NC_PRES) = netcdf_field_info(name='pressure',                       &
-                                                 long_name='pressure',                  &
+            call nc_dset(NC_PRES)%set_info(name='pressure',                       &
+                                           long_name='pressure',                  &
 #endif
-                                                 std_name='',                           &
-                                                 unit='m^2/s^2',                        &
-                                                 dtype=NF90_DOUBLE)
+                                           std_name='',                           &
+                                           unit='m^2/s^2',                        &
+                                           dtype=NF90_DOUBLE)
 
-            nc_dset(NC_DELTA) = netcdf_field_info(name='horizontal_divergence',         &
-                                                  long_name='horizontal divergence',    &
-                                                  std_name='',                          &
-                                                  unit='1/s',                           &
-                                                  dtype=NF90_DOUBLE)
+            call nc_dset(NC_DELTA)%set_info(name='horizontal_divergence',         &
+                                            long_name='horizontal divergence',    &
+                                            std_name='',                          &
+                                            unit='1/s',                           &
+                                            dtype=NF90_DOUBLE)
 
 #ifdef ENABLE_BUOYANCY
-            nc_dset(NC_BUOY) = netcdf_field_info(name='buoyancy',                       &
-                                                 long_name='buoyancy',                  &
-                                                 std_name='',                           &
-                                                 unit='m/s^2',                          &
-                                                 dtype=NF90_DOUBLE)
+            call nc_dset(NC_BUOY)%set_info(name='buoyancy',                       &
+                                           long_name='buoyancy',                  &
+                                           std_name='',                           &
+                                           unit='m/s^2',                          &
+                                           dtype=NF90_DOUBLE)
 
-            nc_dset(NC_BUOY_AN) = netcdf_field_info(name='buoyancy_anomaly',            &
-                                                    long_name='buoyancy anomaly',       &
-                                                    std_name='',                        &
-                                                    unit='m/s^2',                       &
-                                                    dtype=NF90_DOUBLE)
+            call nc_dset(NC_BUOY_AN)%set_info(name='buoyancy_anomaly',            &
+                                              long_name='buoyancy anomaly',       &
+                                              std_name='',                        &
+                                              unit='m/s^2',                       &
+                                              dtype=NF90_DOUBLE)
 #endif
 
         end subroutine set_netcdf_field_info

--- a/src/fields/field_netcdf.f90
+++ b/src/fields/field_netcdf.f90
@@ -37,7 +37,7 @@ module field_netcdf
         logical        :: l_enabled = .false.
 
         contains
-            procedure set_info
+            procedure :: set_info
 
     end type netcdf_field_info
 

--- a/src/fields/field_netcdf.f90
+++ b/src/fields/field_netcdf.f90
@@ -27,18 +27,8 @@ module field_netcdf
     double precision   :: restart_time
     integer            :: n_writes
 
-    type netcdf_field_info
-        character(32)  :: name      = ''
-        character(128) :: long_name = ''
-        character(128) :: std_name  = ''
-        character(16)  :: unit      = ''
-        integer        :: dtype     = -1
-        integer        :: varid     = -1
+    type, extends(netcdf_info) :: netcdf_field_info
         logical        :: l_enabled = .false.
-
-        contains
-            procedure :: set_info
-
     end type netcdf_field_info
 
     integer, parameter :: NC_X_VEL   = 1        &
@@ -68,31 +58,6 @@ module field_netcdf
 
 
     contains
-
-        subroutine set_info(this, name, long_name, std_name, unit, dtype)
-            class(netcdf_field_info), intent(inout) :: this
-            character(*),             intent(in)    :: name
-            character(*),             intent(in)    :: long_name
-            character(*),             intent(in)    :: std_name
-            character(*),             intent(in)    :: unit
-            integer,                  intent(in)    :: dtype
-            integer                                 :: l
-
-            l = len(name)
-            this%name(1:l) = name
-
-            l = len(long_name)
-            this%long_name(1:l) = long_name
-
-            l = len(std_name)
-            this%std_name(1:l) = std_name
-
-            l = len(unit)
-            this%unit(1:l) = unit
-
-            this%dtype = dtype
-
-        end subroutine set_info
 
         ! Create the field file.
         ! @param[in] basename of the file

--- a/src/netcdf/netcdf_utils.f90
+++ b/src/netcdf/netcdf_utils.f90
@@ -18,7 +18,61 @@ module netcdf_utils
 
     character(*), parameter :: version_name = package // '_version'
 
+    type netcdf_info
+        character(32)  :: name      = ''
+        character(128) :: long_name = ''
+        character(128) :: std_name  = ''
+        character(16)  :: unit      = ''
+        integer        :: dtype     = -1
+        integer        :: varid     = -1
+
+        contains
+            procedure :: set_info
+
+    end type netcdf_info
+
     contains
+
+        subroutine set_info(this, name, long_name, std_name, unit, dtype)
+            class(netcdf_info), intent(inout) :: this
+            character(*),       intent(in)    :: name
+            character(*),       intent(in)    :: long_name
+            character(*),       intent(in)    :: std_name
+            character(*),       intent(in)    :: unit
+            integer,            intent(in)    :: dtype
+            integer                           :: l
+
+            l = len(name)
+            if (l > len(this%name)) then
+                call mpi_stop(&
+                    "Error in netcdf_info::set_info: 'name' input '" // name // "' longer than allowed.")
+            endif
+            this%name(1:l) = name
+
+            l = len(long_name)
+            if (l > len(this%long_name)) then
+                call mpi_stop(&
+                    "Error in netcdf_info::set_info: 'long_name' input '" // long_name // "' longer than allowed.")
+            endif
+            this%long_name(1:l) = long_name
+
+            l = len(std_name)
+            if (l > len(this%std_name)) then
+                call mpi_stop(&
+                    "Error in netcdf_info::set_info: 'std_name' input '" // std_name // "' longer than allowed.")
+            endif
+            this%std_name(1:l) = std_name
+
+            l = len(unit)
+            if (l > len(this%unit)) then
+                call mpi_stop(&
+                    "Error in netcdf_info::set_info: 'unit' input '" // unit // "' longer than allowed.")
+            endif
+            this%unit(1:l) = unit
+
+            this%dtype = dtype
+
+        end subroutine set_info
 
         ! This subroutine takes an array of length 3 or 4
         ! single characters defining the dimension names.


### PR DESCRIPTION
For some compilers the problem arises of wrong netcdf_info type initialisation. The assignment of character strings of shorter length than the actual type causes issues; e.g. a name like x_velocity suddently reads x_volocity. An explicit setter function fixes the issue.