### PR TITLE
Make tolerance double precision

### DIFF
--- a/unit-tests/test_diffz_1.f90
+++ b/unit-tests/test_diffz_1.f90
@@ -57,7 +57,7 @@ program test_diffz_1
     call mpi_blocking_reduce(error, MPI_MAX, world)
 
     if (world%rank == world%root) then
-        call print_result_dp('Test diffz', error, atol=1.0e-14)
+        call print_result_dp('Test diffz', error, atol=1.0d-14)
     endif
 
     deallocate(fp)

--- a/unit-tests/test_diffz_2.f90
+++ b/unit-tests/test_diffz_2.f90
@@ -68,7 +68,7 @@ program test_diffz_2
     call mpi_blocking_reduce(error, MPI_MAX, world)
 
     if (world%rank == world%root) then
-        call print_result_dp('Test diffz', error, atol=2.0e-14)
+        call print_result_dp('Test diffz', error, atol=2.0d-14)
     endif
 
     deallocate(fp)

--- a/unit-tests/test_diffz_3.f90
+++ b/unit-tests/test_diffz_3.f90
@@ -68,7 +68,7 @@ program test_diffz_3
     call mpi_blocking_reduce(error, MPI_MAX, world)
 
     if (world%rank == world%root) then
-        call print_result_dp('Test diffz', error, atol=2.0e-13)
+        call print_result_dp('Test diffz', error, atol=2.0d-13)
     endif
 
     deallocate(fp)

--- a/unit-tests/test_diffz_4.f90
+++ b/unit-tests/test_diffz_4.f90
@@ -56,7 +56,7 @@ program test_diffz_4
     call mpi_blocking_reduce(error, MPI_MAX, world)
 
     if (world%rank == world%root) then
-        call print_result_dp('Test diffz', error, atol=1.0e-1)
+        call print_result_dp('Test diffz', error, atol=1.0d-1)
     endif
 
     deallocate(fp)

--- a/unit-tests/test_implicit_rk.f90
+++ b/unit-tests/test_implicit_rk.f90
@@ -91,7 +91,7 @@ program test_implicit_rk
     call mpi_blocking_reduce(error, MPI_MAX, world)
 
     if (world%rank == world%root) then
-        call print_result_dp('Test implicit RK', error, atol=1.0e-12)
+        call print_result_dp('Test implicit RK', error, atol=1.0d-12)
     endif
 
     deallocate(ref)

--- a/unit-tests/test_omp_collapse.f90
+++ b/unit-tests/test_omp_collapse.f90
@@ -95,7 +95,7 @@ program test_omp_collapse
     call mpi_blocking_reduce(error, MPI_MAX, world)
 
     if (world%rank == world%root) then
-        call print_result_dp('Test OMP collapse', error, atol=1.0e-15)
+        call print_result_dp('Test OMP collapse', error, atol=1.0d-15)
     endif
 
     call mpi_env_finalise

--- a/unit-tests/test_vor2vel_1.f90
+++ b/unit-tests/test_vor2vel_1.f90
@@ -96,7 +96,7 @@ program test_vor2vel_1
     call mpi_blocking_reduce(error, MPI_MAX, world)
 
     if (world%rank == world%root) then
-        call print_result_dp('Test vor2vel', error, atol=1.0e-14)
+        call print_result_dp('Test vor2vel', error, atol=1.0d-14)
     endif
 
     deallocate(vel_ref)

--- a/unit-tests/test_vor2vel_2.f90
+++ b/unit-tests/test_vor2vel_2.f90
@@ -101,7 +101,7 @@ program test_vor2vel_2
     call mpi_blocking_reduce(error, MPI_MAX, world)
 
     if (world%rank == world%root) then
-        call print_result_dp('Test vor2vel', error, atol=1.2e-2)
+        call print_result_dp('Test vor2vel', error, atol=1.2d-2)
     endif
 
     deallocate(vel_ref)

--- a/unit-tests/test_vor2vel_3.f90
+++ b/unit-tests/test_vor2vel_3.f90
@@ -76,7 +76,7 @@ program test_vor2vel_3
     call mpi_blocking_reduce(error, MPI_MAX, world)
 
     if (world%rank == world%root) then
-        call print_result_dp('Test vor2vel', error, atol=1.0e-15)
+        call print_result_dp('Test vor2vel', error, atol=1.0d-15)
     endif
 
     deallocate(vel_ref)

--- a/unit-tests/test_vor2vel_4.f90
+++ b/unit-tests/test_vor2vel_4.f90
@@ -76,7 +76,7 @@ program test_vor2vel_4
     call mpi_blocking_reduce(error, MPI_MAX, world)
 
     if (world%rank == world%root) then
-        call print_result_dp('Test vor2vel', error, atol=1.0e-15)
+        call print_result_dp('Test vor2vel', error, atol=1.0d-15)
     endif
 
     deallocate(vel_ref)

--- a/unit-tests/test_vor2vel_5.f90
+++ b/unit-tests/test_vor2vel_5.f90
@@ -77,7 +77,7 @@ program test_vor2vel_5
     call mpi_blocking_reduce(error, MPI_MAX, world)
 
     if (world%rank == world%root) then
-        call print_result_dp('Test vor2vel', error, atol=4.0e-6)
+        call print_result_dp('Test vor2vel', error, atol=4.0d-6)
     endif
 
     deallocate(vel_ref)

--- a/unit-tests/test_zeta.f90
+++ b/unit-tests/test_zeta.f90
@@ -66,7 +66,7 @@ program test_zeta
     call mpi_blocking_reduce(error, MPI_MAX, world)
 
     if (world%rank == world%root) then
-        call print_result_dp('Test zeta', error, atol=1.0e-14)
+        call print_result_dp('Test zeta', error, atol=1.0d-14)
     endif
 
     deallocate(zeta_ref)

--- a/unit-tests/unit_test.f90
+++ b/unit-tests/unit_test.f90
@@ -2,7 +2,7 @@ module unit_test
     implicit none
 
     ! abolute tolerance
-    double precision, parameter :: atol_m = dble(1.0e-15)
+    double precision, parameter :: atol_m = 1.0d-15
 
     private :: atol_m
 


### PR DESCRIPTION
With `ifort` we get an error message in the unit tests because the values of  `atol` are not double precision.